### PR TITLE
Added PoS Validator

### DIFF
--- a/src/logic_utils/PoS_validator.cpp
+++ b/src/logic_utils/PoS_validator.cpp
@@ -4,45 +4,45 @@
 
 using namespace std;
 
-bool isPoSExpression(const string& expr) {
-    bool isOpen = false;
-    int charCount = 0;
-    bool lastWasApostrophe = false;
-    int parenCount = 0;  // To track unmatched parentheses
+bool isValidPoS(const string& expr) {
+    bool isParenthesisOpen = false;
+    int charCountInParen = 0;
+    bool lastCharWasApostrophe = false;
+    int unmatchedParenCount = 0;  // To track unmatched parentheses
 
     for (size_t i = 0; i < expr.size(); i++) {
         char c = expr[i];
 
-        if (isOpen) {
+        if (isParenthesisOpen) {
             if (c == '(') return false; // No nested parentheses
 
             if (c == ')') {
-                if (charCount == 0) return false;  // Invalid if no character before this
-                isOpen = false;
-                charCount = 0;
-                lastWasApostrophe = false;
-                parenCount--;
+                if (charCountInParen == 0) return false;  // Invalid if no character before this
+                isParenthesisOpen = false;
+                charCountInParen = 0;
+                lastCharWasApostrophe = false;
+                unmatchedParenCount--;
             } else if (c == '+') {
-                if (charCount != 1) return false;  // A + should only come after a character (and optional apostrophe)
-                charCount = 0;
-                lastWasApostrophe = false;
+                if (charCountInParen != 1) return false;  // A + should only come after a character (and optional apostrophe)
+                charCountInParen = 0;
+                lastCharWasApostrophe = false;
             } else if (isalpha(c)) {
-                charCount++;
-                if (charCount > 1) return false;  // No two characters in a row
-                lastWasApostrophe = false;  // Resetting the flag
+                charCountInParen++;
+                if (charCountInParen > 1) return false;  // No two characters in a row
+                lastCharWasApostrophe = false;  // Resetting the flag
             } else if (c == '\'') {
-                if (charCount != 1 || lastWasApostrophe) return false;  // Apostrophe should only come after a single character and not another apostrophe
-                lastWasApostrophe = true;
+                if (charCountInParen != 1 || lastCharWasApostrophe) return false;  // Apostrophe should only come after a single character and not another apostrophe
+                lastCharWasApostrophe = true;
             } else if (c == ' ') {
                 // Spaces are allowed, but not immediately after an apostrophe
-                if (lastWasApostrophe) return false;
+                if (lastCharWasApostrophe) return false;
             } else {
                 return false;  // Invalid character inside parenthesis
             }
         } else {
             if (c == '(') {
-                isOpen = true;
-                parenCount++;
+                isParenthesisOpen = true;
+                unmatchedParenCount++;
             } else if (c == ')') {
                 return false;  // Closing parenthesis without an opening one
             } else if (c != ' ' && c != '*' && !isalpha(c)) {
@@ -51,6 +51,6 @@ bool isPoSExpression(const string& expr) {
         }
     }
 
-    return parenCount == 0 && !isOpen;  // Return false if there's unmatched parentheses
+    return unmatchedParenCount == 0 && !isParenthesisOpen;  // Return false if there's unmatched parentheses
 }
 

--- a/src/logic_utils/PoS_validator.cpp
+++ b/src/logic_utils/PoS_validator.cpp
@@ -1,0 +1,56 @@
+#include <iostream>
+#include <cctype>
+#include "PoS_validator.h"
+
+using namespace std;
+
+bool isPoSExpression(const string& expr) {
+    bool isOpen = false;
+    int charCount = 0;
+    bool lastWasApostrophe = false;
+    int parenCount = 0;  // To track unmatched parentheses
+
+    for (size_t i = 0; i < expr.size(); i++) {
+        char c = expr[i];
+
+        if (isOpen) {
+            if (c == '(') return false; // No nested parentheses
+
+            if (c == ')') {
+                if (charCount == 0) return false;  // Invalid if no character before this
+                isOpen = false;
+                charCount = 0;
+                lastWasApostrophe = false;
+                parenCount--;
+            } else if (c == '+') {
+                if (charCount != 1) return false;  // A + should only come after a character (and optional apostrophe)
+                charCount = 0;
+                lastWasApostrophe = false;
+            } else if (isalpha(c)) {
+                charCount++;
+                if (charCount > 1) return false;  // No two characters in a row
+                lastWasApostrophe = false;  // Resetting the flag
+            } else if (c == '\'') {
+                if (charCount != 1 || lastWasApostrophe) return false;  // Apostrophe should only come after a single character and not another apostrophe
+                lastWasApostrophe = true;
+            } else if (c == ' ') {
+                // Spaces are allowed, but not immediately after an apostrophe
+                if (lastWasApostrophe) return false;
+            } else {
+                return false;  // Invalid character inside parenthesis
+            }
+        } else {
+            if (c == '(') {
+                isOpen = true;
+                parenCount++;
+            } else if (c == ')') {
+                return false;  // Closing parenthesis without an opening one
+            } else if (c != ' ' && c != '*' && !isalpha(c)) {
+                return false;  // Invalid character outside parenthesis
+            }
+        }
+    }
+
+    return parenCount == 0 && !isOpen;  // Return false if there's unmatched parentheses
+}
+

--- a/src/logic_utils/PoS_validator.h
+++ b/src/logic_utils/PoS_validator.h
@@ -1,10 +1,10 @@
- #ifndef POS_EXPRESSION_H
+#ifndef POS_EXPRESSION_H
 #define POS_EXPRESSION_H
 
 #include <string>
 
 using namespace std;
 
-bool isPoSExpression(const string& expr);
+bool isValidPoS(const string& expr);
 
 #endif // POS_EXPRESSION_H 

--- a/src/logic_utils/PoS_validator.h
+++ b/src/logic_utils/PoS_validator.h
@@ -1,0 +1,10 @@
+ #ifndef POS_EXPRESSION_H
+#define POS_EXPRESSION_H
+
+#include <string>
+
+using namespace std;
+
+bool isPoSExpression(const string& expr);
+
+#endif // POS_EXPRESSION_H 

--- a/tests/test_PoS_validator.cpp
+++ b/tests/test_PoS_validator.cpp
@@ -1,110 +1,197 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch_test_macros.hpp>
 
-#include "../src/logic_utils/PoS_validator.h"   // Adjust the path accordingly
+#include "../src/logic_utils/PoS_validator.h"
 
 TEST_CASE("Validation of the term (x+y)(x+z)") {
-    REQUIRE( isPoSExpression("(x+y)(x+z)") == true );
+    REQUIRE( isValidPoS("(x+y)(x+z)") == true );
 }
 TEST_CASE("Validation of the term x") {
-    REQUIRE( isPoSExpression("x") == true );
+    REQUIRE( isValidPoS("x") == true );
 }
 
 TEST_CASE("Validation of the term x+y") {
-    REQUIRE( isPoSExpression("x+y") == false );
+    REQUIRE( isValidPoS("x+y") == false );
 }
 
 TEST_CASE("Validation of the term (x)(y+z)") {
-    REQUIRE( isPoSExpression("(x)(y+z)") == true );
+    REQUIRE( isValidPoS("(x)(y+z)") == true );
 }
 
 TEST_CASE("Validation of the term (x+y+z)(a+b+c)") {
-    REQUIRE( isPoSExpression("(x+y+z)(a+b+c)") == true );
+    REQUIRE( isValidPoS("(x+y+z)(a+b+c)") == true );
 }
 
 TEST_CASE("Validation of the term (x+y)(z)") {
-    REQUIRE( isPoSExpression("(x+y)(z)") == true );
+    REQUIRE( isValidPoS("(x+y)(z)") == true );
 }
 
 TEST_CASE("Validation of the term (x+y)(z+w)(a+b)") {
-    REQUIRE( isPoSExpression("(x+y)(z+w)(a+b)") == true );
+    REQUIRE( isValidPoS("(x+y)(z+w)(a+b)") == true );
 }
 
 TEST_CASE("Validation of the term (x+y+z)(x+y)") {
-    REQUIRE( isPoSExpression("(x+y+z)(x+y)") == true );
+    REQUIRE( isValidPoS("(x+y+z)(x+y)") == true );
 }
 
 TEST_CASE("Validation of the term x+y+z") {
-    REQUIRE( isPoSExpression("x+y+z") == false );
+    REQUIRE( isValidPoS("x+y+z") == false );
 }
 
 TEST_CASE("Validation of the term x*(y+z)") {
-    REQUIRE( isPoSExpression("x*(y+z)") == true );
+    REQUIRE( isValidPoS("x*(y+z)") == true );
 }
 
 TEST_CASE("Validation of the term (x+y)*(z+w)*(a+b)*(c+d)") {
-    REQUIRE( isPoSExpression("(x+y)*(z+w)*(a+b)*(c+d)") == true );
+    REQUIRE( isValidPoS("(x+y)*(z+w)*(a+b)*(c+d)") == true );
 }
 
 TEST_CASE("Validation of the term (x+y)(z+w)(a+b)c") {
-    REQUIRE( isPoSExpression("(x+y)(z+w)(a+b)c") == true );
+    REQUIRE( isValidPoS("(x+y)(z+w)(a+b)c") == true );
 }
 TEST_CASE("Validation of the term (x+y')(x'+z)") {
-    REQUIRE( isPoSExpression("(x+y')(x'+z)") == true );
+    REQUIRE( isValidPoS("(x+y')(x'+z)") == true );
 }
 
 TEST_CASE("Validation of the term (x'+y)(x+z')") {
-    REQUIRE( isPoSExpression("(x'+y)(x+z')") == true );
+    REQUIRE( isValidPoS("(x'+y)(x+z')") == true );
 }
 
 TEST_CASE("Validation of the term (x+y+z')(a'+b+c)") {
-    REQUIRE( isPoSExpression("(x+y+z')(a'+b+c)") == true );
+    REQUIRE( isValidPoS("(x+y+z')(a'+b+c)") == true );
 }
 
 TEST_CASE("Validation of the term (x'+y'+z)(a+b'+c')") {
-    REQUIRE( isPoSExpression("(x'+y'+z)(a+b'+c')") == true );
+    REQUIRE( isValidPoS("(x'+y'+z)(a+b'+c')") == true );
 }
 
 TEST_CASE("Validation of the term (x+y')(z'+w)(a'+b)") {
-    REQUIRE( isPoSExpression("(x+y')(z'+w)(a'+b)") == true );
+    REQUIRE( isValidPoS("(x+y')(z'+w)(a'+b)") == true );
 }
 
 TEST_CASE("Validation of the term (x+y'+z)(x'+y)") {
-    REQUIRE( isPoSExpression("(x+y'+z)(x'+y)") == true );
+    REQUIRE( isValidPoS("(x+y'+z)(x'+y)") == true );
 }
 
 TEST_CASE("Validation of the term (x'+y+z')(x+y')") {
-    REQUIRE( isPoSExpression("(x'+y+z')(x+y')") == true );
+    REQUIRE( isValidPoS("(x'+y+z')(x+y')") == true );
 }
 
 TEST_CASE("Validation of the term (x+y')(z+w')(a+b')") {
-    REQUIRE( isPoSExpression("(x+y')(z+w')(a+b')") == true );
+    REQUIRE( isValidPoS("(x+y')(z+w')(a+b')") == true );
 }
 
 TEST_CASE("Validation of the term (x'+y')(z'+w)(a'+b')") {
-    REQUIRE( isPoSExpression("(x'+y')(z'+w)(a'+b')") == true );
+    REQUIRE( isValidPoS("(x'+y')(z'+w)(a'+b')") == true );
 }
 
 TEST_CASE("Validation of the term (x+y)(x'+y')") {
-    REQUIRE( isPoSExpression("(x+y)(x'+y')") == true );
+    REQUIRE( isValidPoS("(x+y)(x'+y')") == true );
 }
 
 TEST_CASE("Validation of the term (x'+y')(z+w')") {
-    REQUIRE( isPoSExpression("(x'+y')(z+w')") == true );
+    REQUIRE( isValidPoS("(x'+y')(z+w')") == true );
 }
 
 TEST_CASE("Validation of the term x+y'+z") {
-    REQUIRE( isPoSExpression("x+y'+z") == false );
+    REQUIRE( isValidPoS("x+y'+z") == false );
 }
 
 TEST_CASE("Validation of the term x'(y+z)") {
-    REQUIRE( isPoSExpression("x'(y+z)") == false );
+    REQUIRE( isValidPoS("x'(y+z)") == false );
 }
 
 TEST_CASE("Validation of the term (x+y')*(z'+w')*(a+b)*(c'+d)") {
-    REQUIRE( isPoSExpression("(x+y')*(z'+w')*(a+b)*(c'+d)") == true );
+    REQUIRE( isValidPoS("(x+y')*(z'+w')*(a+b)*(c'+d)") == true );
+}
+TEST_CASE("Validation of the term (x+y')(z+w')(a+b)c'") {
+    REQUIRE( isValidPoS("(x+y')(z+w')(a+b)c'") == false );
 }
 
-TEST_CASE("Validation of the term (x+y')(z+w')(a+b)c'") {
-    REQUIRE( isPoSExpression("(x+y')(z+w')(a+b)c'") == false );
+TEST_CASE("Validation of the term x+y'z+w'") {
+    REQUIRE( isValidPoS("x+y'z+w'") == false );
 }
+
+TEST_CASE("Validation of the term (x+y')*z+w'") {
+    REQUIRE( isValidPoS("(x+y')*z+w'") == false );
+}
+
+TEST_CASE("Validation of the term (x+y')+(z+w')") {
+    REQUIRE( isValidPoS("(x+y')+(z+w')") == false );
+}
+
+TEST_CASE("Validation of the term (x+y')(z+w')(a+b)+c'") {
+    REQUIRE( isValidPoS("(x+y')(z+w')(a+b)+c'") == false );
+}
+
+TEST_CASE("Validation of the term (x+y')(z+w')(a+b)") {
+    REQUIRE( isValidPoS("(x+y')(z+w')(a+b)") == true );
+}
+TEST_CASE("Validation of the term (a+b)(c+d')e+f'") {
+    REQUIRE( isValidPoS("(a+b)(c+d')e+f'") == false );
+}
+
+TEST_CASE("Validation of the term (m+n')+(o+p')") {
+    REQUIRE( isValidPoS("(m+n')+(o+p')") == false );
+}
+
+TEST_CASE("Validation of the term (r+s')(t+u')") {
+    REQUIRE( isValidPoS("(r+s')(t+u')") == true );
+}
+
+TEST_CASE("Validation of the term (x+y')(z+w')*a'") {
+    REQUIRE( isValidPoS("(x+y')(z+w')*a'") == false );
+}
+
+TEST_CASE("Validation of the term (i+j')(k+l')+(m+n')") {
+    REQUIRE( isValidPoS("(i+j')(k+l')+(m+n')") == false );
+}
+
+TEST_CASE("Validation of the term a'+b'c+d'") {
+    REQUIRE( isValidPoS("a'+b'c+d'") == false );
+}
+
+TEST_CASE("Validation of the term (a+b)(c+d')(e+f')") {
+    REQUIRE( isValidPoS("(a+b)(c+d')(e+f')") == true );
+}
+
+TEST_CASE("Validation of the term a+b(c+d')") {
+    REQUIRE( isValidPoS("a+b(c+d')") == false );
+}
+TEST_CASE("Validation of the term (p+q)+(r+s')(t+u')") {
+    REQUIRE( isValidPoS("(p+q)+(r+s')(t+u')") == false );
+}
+
+TEST_CASE("Validation of the term (v+w')x'") {
+    REQUIRE( isValidPoS("(v+w')x'") == false );
+}
+
+TEST_CASE("Validation of the term (a+b')(c+d)(e+f')+g'") {
+    REQUIRE( isValidPoS("(a+b')(c+d)(e+f')+g'") == false );
+}
+
+TEST_CASE("Validation of the term (h+i')(j+k)l'") {
+    REQUIRE( isValidPoS("(h+i')(j+k)l'") == false );
+}
+
+TEST_CASE("Validation of the term (m+n)o'+(p+q)"){
+    REQUIRE( isValidPoS("(m+n)o'+(p+q)") == false );
+}
+
+TEST_CASE("Validation of the term (r+s')(t+u)(v+w')+x'"){
+    REQUIRE( isValidPoS("(r+s')(t+u)(v+w')+x'") == false );
+}
+
+TEST_CASE("Validation of the term y+z(a+b)"){
+    REQUIRE( isValidPoS("y+z(a+b)") == false );
+}
+
+TEST_CASE("Validation of the term (c+d')+(e+f')g'"){
+    REQUIRE( isValidPoS("(c+d')+(e+f')g'") == false );
+}
+TEST_CASE("Validation of the term hamada"){
+    REQUIRE( isValidPoS("hamada") == true );
+}
+TEST_CASE("Validation of the term xyz50"){
+    REQUIRE( isValidPoS("xyz50") == false );
+    }

--- a/tests/test_PoS_validator.cpp
+++ b/tests/test_PoS_validator.cpp
@@ -1,0 +1,110 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_test_macros.hpp>
+
+#include "../src/logic_utils/PoS_validator.h"   // Adjust the path accordingly
+
+TEST_CASE("Validation of the term (x+y)(x+z)") {
+    REQUIRE( isPoSExpression("(x+y)(x+z)") == true );
+}
+TEST_CASE("Validation of the term x") {
+    REQUIRE( isPoSExpression("x") == true );
+}
+
+TEST_CASE("Validation of the term x+y") {
+    REQUIRE( isPoSExpression("x+y") == false );
+}
+
+TEST_CASE("Validation of the term (x)(y+z)") {
+    REQUIRE( isPoSExpression("(x)(y+z)") == true );
+}
+
+TEST_CASE("Validation of the term (x+y+z)(a+b+c)") {
+    REQUIRE( isPoSExpression("(x+y+z)(a+b+c)") == true );
+}
+
+TEST_CASE("Validation of the term (x+y)(z)") {
+    REQUIRE( isPoSExpression("(x+y)(z)") == true );
+}
+
+TEST_CASE("Validation of the term (x+y)(z+w)(a+b)") {
+    REQUIRE( isPoSExpression("(x+y)(z+w)(a+b)") == true );
+}
+
+TEST_CASE("Validation of the term (x+y+z)(x+y)") {
+    REQUIRE( isPoSExpression("(x+y+z)(x+y)") == true );
+}
+
+TEST_CASE("Validation of the term x+y+z") {
+    REQUIRE( isPoSExpression("x+y+z") == false );
+}
+
+TEST_CASE("Validation of the term x*(y+z)") {
+    REQUIRE( isPoSExpression("x*(y+z)") == true );
+}
+
+TEST_CASE("Validation of the term (x+y)*(z+w)*(a+b)*(c+d)") {
+    REQUIRE( isPoSExpression("(x+y)*(z+w)*(a+b)*(c+d)") == true );
+}
+
+TEST_CASE("Validation of the term (x+y)(z+w)(a+b)c") {
+    REQUIRE( isPoSExpression("(x+y)(z+w)(a+b)c") == true );
+}
+TEST_CASE("Validation of the term (x+y')(x'+z)") {
+    REQUIRE( isPoSExpression("(x+y')(x'+z)") == true );
+}
+
+TEST_CASE("Validation of the term (x'+y)(x+z')") {
+    REQUIRE( isPoSExpression("(x'+y)(x+z')") == true );
+}
+
+TEST_CASE("Validation of the term (x+y+z')(a'+b+c)") {
+    REQUIRE( isPoSExpression("(x+y+z')(a'+b+c)") == true );
+}
+
+TEST_CASE("Validation of the term (x'+y'+z)(a+b'+c')") {
+    REQUIRE( isPoSExpression("(x'+y'+z)(a+b'+c')") == true );
+}
+
+TEST_CASE("Validation of the term (x+y')(z'+w)(a'+b)") {
+    REQUIRE( isPoSExpression("(x+y')(z'+w)(a'+b)") == true );
+}
+
+TEST_CASE("Validation of the term (x+y'+z)(x'+y)") {
+    REQUIRE( isPoSExpression("(x+y'+z)(x'+y)") == true );
+}
+
+TEST_CASE("Validation of the term (x'+y+z')(x+y')") {
+    REQUIRE( isPoSExpression("(x'+y+z')(x+y')") == true );
+}
+
+TEST_CASE("Validation of the term (x+y')(z+w')(a+b')") {
+    REQUIRE( isPoSExpression("(x+y')(z+w')(a+b')") == true );
+}
+
+TEST_CASE("Validation of the term (x'+y')(z'+w)(a'+b')") {
+    REQUIRE( isPoSExpression("(x'+y')(z'+w)(a'+b')") == true );
+}
+
+TEST_CASE("Validation of the term (x+y)(x'+y')") {
+    REQUIRE( isPoSExpression("(x+y)(x'+y')") == true );
+}
+
+TEST_CASE("Validation of the term (x'+y')(z+w')") {
+    REQUIRE( isPoSExpression("(x'+y')(z+w')") == true );
+}
+
+TEST_CASE("Validation of the term x+y'+z") {
+    REQUIRE( isPoSExpression("x+y'+z") == false );
+}
+
+TEST_CASE("Validation of the term x'(y+z)") {
+    REQUIRE( isPoSExpression("x'(y+z)") == false );
+}
+
+TEST_CASE("Validation of the term (x+y')*(z'+w')*(a+b)*(c'+d)") {
+    REQUIRE( isPoSExpression("(x+y')*(z'+w')*(a+b)*(c'+d)") == true );
+}
+
+TEST_CASE("Validation of the term (x+y')(z+w')(a+b)c'") {
+    REQUIRE( isPoSExpression("(x+y')(z+w')(a+b)c'") == false );
+}


### PR DESCRIPTION
The program processes a string and parses it to validate whether it is in the products of sum (PoS) format according to the following rules:

- When matched with a `(` it sets a boolean variable `isopen` to `true`.
- While `isopen` is `true`, it matches singular (not multiplied) alphabetical characters that might be followed by the `NOT` operator `'` and separated by a `+` all while ignoring whitespaces.
- While `isopen` is `false`, the parser looks for the following an asterisk, empty-space, or a whitespace to ensure that the next opoeration is a product.
- There is a code in the background that ensures the balance of parentheses.

This PR resolves #5 