### PR TITLE
Added SoP Validator

### DIFF
--- a/src/logic_utils/SoP_validator.cpp
+++ b/src/logic_utils/SoP_validator.cpp
@@ -5,13 +5,13 @@
 using namespace std;
 
 
-bool isSoPExpression(const std::string& expr) {
-    int parenCount = 0;
+bool isValidSoP(const std::string& expr) {
+    int unmatchedParenCount = 0;
     bool lastWasAlpha = false;
     bool lastWasOperator = false;
-    bool lastWasApostrophe = false;
+    bool lastCharWasApostrophe = false;
     bool endedWithOperator = false;
-    bool withinParen = false;
+    bool isParenthesisOpen = false;
     bool hadSummationInsideParen = false;
 
     for (size_t i = 0; i < expr.size(); i++) {
@@ -20,40 +20,40 @@ bool isSoPExpression(const std::string& expr) {
         if (c == ' ') continue;  // Ignore spaces
 
         if (c == '(') {
-            withinParen = true;
+            isParenthesisOpen = true;
             hadSummationInsideParen = false;
-            parenCount++;
+            unmatchedParenCount++;
             endedWithOperator = false;
             continue;
         }
 
         if (c == ')') {
-            if (lastWasOperator || !withinParen) return false;
+            if (lastWasOperator || !isParenthesisOpen) return false;
             if (hadSummationInsideParen) {
                 size_t nextCharIndex = i + 1;
                 while (nextCharIndex < expr.size() && expr[nextCharIndex] == ' ') nextCharIndex++;  // Skip spaces
                 if (nextCharIndex == expr.size() || expr[nextCharIndex] != '+') return false;
             }
-            withinParen = false;
-            parenCount--;
+            isParenthesisOpen = false;
+            unmatchedParenCount--;
             continue;
         }
 
         if (c == '+') {
-            if (!lastWasAlpha && !lastWasApostrophe) return false;
-            if (withinParen) hadSummationInsideParen = true;
+            if (!lastWasAlpha && !lastCharWasApostrophe) return false;
+            if (isParenthesisOpen) hadSummationInsideParen = true;
             lastWasOperator = true;
             lastWasAlpha = false;
-            lastWasApostrophe = false;
+            lastCharWasApostrophe = false;
             endedWithOperator = true;
             continue;
         }
 
         if (c == '*') {
-            if ((!lastWasAlpha && !lastWasApostrophe) || lastWasOperator) return false;
+            if ((!lastWasAlpha && !lastCharWasApostrophe) || lastWasOperator) return false;
             lastWasOperator = true;
             lastWasAlpha = false;
-            lastWasApostrophe = false;
+            lastCharWasApostrophe = false;
             endedWithOperator = true;
             continue;
         }
@@ -61,7 +61,7 @@ bool isSoPExpression(const std::string& expr) {
         if (isalpha(c)) {
             lastWasAlpha = true;
             lastWasOperator = false;
-            lastWasApostrophe = false;
+            lastCharWasApostrophe = false;
             endedWithOperator = false;
             continue;
         }
@@ -69,7 +69,7 @@ bool isSoPExpression(const std::string& expr) {
         if (c == '\'') {
             if (!lastWasAlpha) return false;
             lastWasAlpha = false;
-            lastWasApostrophe = true;
+            lastCharWasApostrophe = true;
             lastWasOperator = false;
             endedWithOperator = false;
             continue;
@@ -79,5 +79,5 @@ bool isSoPExpression(const std::string& expr) {
         return false;
     }
 
-    return parenCount == 0 && !endedWithOperator;
+    return unmatchedParenCount == 0 && !endedWithOperator;
 }

--- a/src/logic_utils/SoP_validator.h
+++ b/src/logic_utils/SoP_validator.h
@@ -6,6 +6,6 @@
 #include "SoP_validator.h"
 using namespace std;
 
-bool isSoPExpression(const string& expr);
+bool isValidSoP(const string& expr);
 
 #endif

--- a/tests/test_SoP_validator.cpp
+++ b/tests/test_SoP_validator.cpp
@@ -4,230 +4,230 @@
 #include "../src/logic_utils/SoP_validator.h"
 
 TEST_CASE( "Validation of expression x + y") {
-          REQUIRE(isSoPExpression("x + y") == true);
+          REQUIRE(isValidSoP("x + y") == true);
 }
           
 TEST_CASE("Valid SoP: (A*B') + (C*D)") {
-    REQUIRE(isSoPExpression("(A*B') + (C*D)") == true);
+    REQUIRE(isValidSoP("(A*B') + (C*D)") == true);
 }
 
 TEST_CASE("Valid SoP: (X'*Y) + (Z*W') + (M*N)") {
-    REQUIRE(isSoPExpression("(X'*Y) + (Z*W') + (M*N)") == true);
+    REQUIRE(isValidSoP("(X'*Y) + (Z*W') + (M*N)") == true);
 }
 
 TEST_CASE("Valid SoP: (A*B*C')") {
-    REQUIRE(isSoPExpression("(A*B*C')") == true);
+    REQUIRE(isValidSoP("(A*B*C')") == true);
 }
 
 TEST_CASE("Valid SoP: (J'*K*L) + (N*O'*P)") {
-    REQUIRE(isSoPExpression("(J'*K*L) + (N*O'*P)") == true);
+    REQUIRE(isValidSoP("(J'*K*L) + (N*O'*P)") == true);
 }
 
 TEST_CASE("Valid SoP: (U*V') + (W*X) + (Y*Z)") {
-    REQUIRE(isSoPExpression("(U*V') + (W*X) + (Y*Z)") == true);
+    REQUIRE(isValidSoP("(U*V') + (W*X) + (Y*Z)") == true);
 }
 
 TEST_CASE("Valid SoP: (G*H*I')") {
-    REQUIRE(isSoPExpression("(G*H*I')") == true);
+    REQUIRE(isValidSoP("(G*H*I')") == true);
 }
 
 TEST_CASE("Valid SoP: (A+B) + (C*D)") {
-    REQUIRE(isSoPExpression("(A+B) + (C*D)") == true);
+    REQUIRE(isValidSoP("(A+B) + (C*D)") == true);
 }
 
 TEST_CASE("Invalid SoP: (X'*Y) * (Z+W')") {
-    REQUIRE(isSoPExpression("(X'*Y) * (Z+W')") == false);
+    REQUIRE(isValidSoP("(X'*Y) * (Z+W')") == false);
 }
 
 TEST_CASE("Invalid SoP: (A'*B*) + (C*D)") {
-    REQUIRE(isSoPExpression("(A'*B*) + (C*D)") == false);
+    REQUIRE(isValidSoP("(A'*B*) + (C*D)") == false);
 }
 
 TEST_CASE("Valid SoP: A*B*C'") {
-    REQUIRE(isSoPExpression("A*B*C'") == true);
+    REQUIRE(isValidSoP("A*B*C'") == true);
 }
 
 TEST_CASE("Valid SoP: (J'*K*L M*N)") {
-    REQUIRE(isSoPExpression("(J'*K*L M*N)") == true);
+    REQUIRE(isValidSoP("(J'*K*L M*N)") == true);
 }
 
 TEST_CASE("Valid SoP: (U*V') + W*X + (Y*Z)") {
-    REQUIRE(isSoPExpression("(U*V') + W*X + (Y*Z)") == true);
+    REQUIRE(isValidSoP("(U*V') + W*X + (Y*Z)") == true);
 }
 
 TEST_CASE("Inalid SoP: (G*H*I') + (A*B'") {
-    REQUIRE(isSoPExpression("(G*H*I') + (A*B'") == false);
+    REQUIRE(isValidSoP("(G*H*I') + (A*B'") == false);
 }
 TEST_CASE("Invalid SoP: 55555") {
-    REQUIRE(isSoPExpression("55555") == false);
+    REQUIRE(isValidSoP("55555") == false);
 }
 TEST_CASE("Valid SoP: Hamada") {
-    REQUIRE(isSoPExpression("Hamada") == true);
+    REQUIRE(isValidSoP("Hamada") == true);
 }
 TEST_CASE("Validation of SoP expression: a + b'c + d'e") {
-    REQUIRE(isSoPExpression("a + b'c + d'e") == true);
+    REQUIRE(isValidSoP("a + b'c + d'e") == true);
 }
 
 TEST_CASE("Validation of SoP expression: a'bc' + def + g'h'i'") {
-    REQUIRE(isSoPExpression("a'bc' + def + g'h'i'") == true);
+    REQUIRE(isValidSoP("a'bc' + def + g'h'i'") == true);
 }
 
 TEST_CASE("Validation of SoP expression: w'x'y + z") {
-    REQUIRE(isSoPExpression("w'x'y + z") == true);
+    REQUIRE(isValidSoP("w'x'y + z") == true);
 }
 
 TEST_CASE("Validation of SoP expression: m'n + op'q'r'") {
-    REQUIRE(isSoPExpression("m'n + op'q'r'") == true);
+    REQUIRE(isValidSoP("m'n + op'q'r'") == true);
 }
 
 TEST_CASE("Validation of SoP expression: uv + w'x'y'z") {
-    REQUIRE(isSoPExpression("uv + w'x'y'z") == true);
+    REQUIRE(isValidSoP("uv + w'x'y'z") == true);
 }
 TEST_CASE("Validation of SoP expression: a' + b' + c") {
-    REQUIRE(isSoPExpression("a' + b' + c") == true);
+    REQUIRE(isValidSoP("a' + b' + c") == true);
 }
 
 TEST_CASE("Validation of SoP expression: a*b + cd' + e'f'g") {
-    REQUIRE(isSoPExpression("a*b + cd' + e'f'g") == true);
+    REQUIRE(isValidSoP("a*b + cd' + e'f'g") == true);
 }
 
 TEST_CASE("Validation of SoP expression: a(b*c)") {
-    REQUIRE(isSoPExpression("a(b*c)") == true);
+    REQUIRE(isValidSoP("a(b*c)") == true);
 }
 
 TEST_CASE("Validation of SoP expression: ab'c + d+e + f'gh'") {
-    REQUIRE(isSoPExpression("ab'c + d+e + f'gh'") == true);
+    REQUIRE(isValidSoP("ab'c + d+e + f'gh'") == true);
 }
 
 TEST_CASE("Validation of SoP expression: (a*b)(c*d)") {
-    REQUIRE(isSoPExpression("(a*b)(c*d)") == true);
+    REQUIRE(isValidSoP("(a*b)(c*d)") == true);
 }
 
 TEST_CASE("Validation of SoP expression: a*b*c'*d'e'f") {
-    REQUIRE(isSoPExpression("a*b*c'*d'e'f") == true);
+    REQUIRE(isValidSoP("a*b*c'*d'e'f") == true);
 }
 
 TEST_CASE("Validation of SoP expression: abc*def*g'hi") {
-    REQUIRE(isSoPExpression("abc*def*g'hi") == true);
+    REQUIRE(isValidSoP("abc*def*g'hi") == true);
 }
 // Test cases for valid SoP expressions
 TEST_CASE("Validation of SoP: (a * b) + (c * d')") {
-    REQUIRE(isSoPExpression("(a * b) + (c * d')") == true);
+    REQUIRE(isValidSoP("(a * b) + (c * d')") == true);
 }
 
 TEST_CASE("Validation of SoP: a + b") {
-    REQUIRE(isSoPExpression("a + b") == true);
+    REQUIRE(isValidSoP("a + b") == true);
 }
 
 TEST_CASE("Validation of SoP: (a * b * c) + d") {
-    REQUIRE(isSoPExpression("(a * b * c) + d") == true);
+    REQUIRE(isValidSoP("(a * b * c) + d") == true);
 }
 
 TEST_CASE("Validation of SoP: x + (y * z')") {
-    REQUIRE(isSoPExpression("x + (y * z')") == true);
+    REQUIRE(isValidSoP("x + (y * z')") == true);
 }
 
 TEST_CASE("Validation of SoP: (m * n') + o") {
-    REQUIRE(isSoPExpression("(m * n') + o") == true);
+    REQUIRE(isValidSoP("(m * n') + o") == true);
 }
 
 // Test cases for invalid SoP expressions
 TEST_CASE("Validation of SoP: a * b") {
-    REQUIRE(isSoPExpression("a * b") == true);
+    REQUIRE(isValidSoP("a * b") == true);
 }
 
 TEST_CASE("Validation of non-SoP: (a + b) * c") {
-    REQUIRE(isSoPExpression("(a + b) * c") == false);
+    REQUIRE(isValidSoP("(a + b) * c") == false);
 }
 
 TEST_CASE("Validation of SoP: (x * y) * z") {
-    REQUIRE(isSoPExpression("(x * y) * z") == true);
+    REQUIRE(isValidSoP("(x * y) * z") == true);
 }
 
 TEST_CASE("Validation of non-SoP: (a + b') * (c + d)") {
-    REQUIRE(isSoPExpression("(a + b') * (c + d)") == false);
+    REQUIRE(isValidSoP("(a + b') * (c + d)") == false);
 }
 
 TEST_CASE("Validation of SoP: w + x + y * z") {
-    REQUIRE(isSoPExpression("w + x + y * z") == true);
+    REQUIRE(isValidSoP("w + x + y * z") == true);
 }
 TEST_CASE("Validation of non_SoP expression: a*") {
-    REQUIRE(isSoPExpression("a*") == false);
+    REQUIRE(isValidSoP("a*") == false);
 }
 
 TEST_CASE("Validation of non_SoP expression: a + b* + c") {
-    REQUIRE(isSoPExpression("a + b* + c") == false);
+    REQUIRE(isValidSoP("a + b* + c") == false);
 }
 
 TEST_CASE("Validation of non_SoP expression: a + b + c*") {
-    REQUIRE(isSoPExpression("a + b + c*") == false);
+    REQUIRE(isValidSoP("a + b + c*") == false);
 }
 
 TEST_CASE("Validation of non_SoP expression: **a + b") {
-    REQUIRE(isSoPExpression("**a + b") == false);
+    REQUIRE(isValidSoP("**a + b") == false);
 }
 
 TEST_CASE("Validation of non_SoP expression: a + ") {
-    REQUIRE(isSoPExpression("a + ") == false);
+    REQUIRE(isValidSoP("a + ") == false);
 }
 
 TEST_CASE("Validation of non_SoP expression: a + + b") {
-    REQUIRE(isSoPExpression("a + + b") == false);
+    REQUIRE(isValidSoP("a + + b") == false);
 }
 
 TEST_CASE("Validation of SoP expression: a * b * c") {
-    REQUIRE(isSoPExpression("a * b * c") == true);
+    REQUIRE(isValidSoP("a * b * c") == true);
 }
 
 TEST_CASE("Validation of expression: 'a + b") {
-    REQUIRE(isSoPExpression("'a + b") == false);
+    REQUIRE(isValidSoP("'a + b") == false);
 }
 
 TEST_CASE("Validation of expression: a + b*c + d") {
-    REQUIRE(isSoPExpression("a + b*c + d") == true);
+    REQUIRE(isValidSoP("a + b*c + d") == true);
 }
 
 TEST_CASE("Validation of non_SoP expression: a**b + c") {
-    REQUIRE(isSoPExpression("a**b + c") == false);
+    REQUIRE(isValidSoP("a**b + c") == false);
 }
 
 TEST_CASE("Validation of SoP expression: a' * b") {
-    REQUIRE(isSoPExpression("a' * b") == true);
+    REQUIRE(isValidSoP("a' * b") == true);
 }
 
 TEST_CASE("Validation of SoP expression: a * b' + c'") {
-    REQUIRE(isSoPExpression("a * b' + c'") == true);
+    REQUIRE(isValidSoP("a * b' + c'") == true);
 }
 
 TEST_CASE("Validation of expression: a + (b * c)") {
-    REQUIRE(isSoPExpression("a + (b * c)") == true);
+    REQUIRE(isValidSoP("a + (b * c)") == true);
 }
 
 TEST_CASE("Validation of expression: a*b' * c*d") {
-    REQUIRE(isSoPExpression("a*b' * c*d") == true);
+    REQUIRE(isValidSoP("a*b' * c*d") == true);
 }
 
 TEST_CASE("Validation of non_SoP expression: a*b* + c*d") {
-    REQUIRE(isSoPExpression("a*b* + c*d") == false);
+    REQUIRE(isValidSoP("a*b* + c*d") == false);
 }
 
 TEST_CASE("Validation of non_SoP expression: a++b * c") {
-    REQUIRE(isSoPExpression("a++b * c") == false);
+    REQUIRE(isValidSoP("a++b * c") == false);
 }
 
 TEST_CASE("Validation of non_SoP expression: a*'*b") {
-    REQUIRE(isSoPExpression("a*'*b") == false);
+    REQUIRE(isValidSoP("a*'*b") == false);
 }
 
 TEST_CASE("Validation of non_SoP expression: '") {
-    REQUIRE(isSoPExpression("'") == false);
+    REQUIRE(isValidSoP("'") == false);
 }
 
 TEST_CASE("Validation of SoP expression: a*b'c*d") {
-    REQUIRE(isSoPExpression("a*b'c*d") == true);
+    REQUIRE(isValidSoP("a*b'c*d") == true);
 }
 
 TEST_CASE("Validation of non_SoP expression: a*b + + c*d") {
-    REQUIRE(isSoPExpression("a*b + + c*d") == false);
+    REQUIRE(isValidSoP("a*b + + c*d") == false);
 }
 


### PR DESCRIPTION
The program takes in a string and parses it looking for SoP (Sum of Products) expressions by the following set of rules:

- Rejecting expressions in PoS form.
- Considering single product terms are SoP.
- Product terms separated by + operator are considered SoP.
- Ignoring white space between operators such as `+` or `*`.
- `OR`ed terms inside of parentheses are allowed if and only if they are followed by an `OR` operator once the parentheses are closed.

This PR resolves issue #18