### PR TITLE
Minterms not covered by epis

### DIFF
--- a/src/logic_utils/maxterm.cpp
+++ b/src/logic_utils/maxterm.cpp
@@ -25,8 +25,8 @@ string maxtermToString(Maxterm maxterm, vector<Token> uniqueVariables) {
   return maxtermString;
 }
 
-string maxtermsToString(vector<Maxterm> maxterms,
-                        vector<Token> uniqueVariables) {
+string canonicalPoSToString(vector<Maxterm> maxterms,
+                            vector<Token> uniqueVariables) {
   string maxtermsString = "";
 
   for (int i = 0; i < maxterms.size(); i++) {

--- a/src/logic_utils/maxterm.h
+++ b/src/logic_utils/maxterm.h
@@ -16,7 +16,7 @@ struct Maxterm {
 
 string maxtermToString(Maxterm maxterm, vector<Token> uniqueVariables);
 
-string maxtermsToString(vector<Maxterm> maxterms,
-                        vector<Token> uniqueVariables);
+string canonicalPoSToString(vector<Maxterm> maxterms,
+                            vector<Token> uniqueVariables);
 
 #endif  // MAXTERM_H

--- a/src/logic_utils/minterm.cpp
+++ b/src/logic_utils/minterm.cpp
@@ -21,8 +21,8 @@ string mintermToString(Minterm minterm, vector<Token> uniqueVariables) {
   return mintermString;
 }
 
-string mintermsToString(vector<Minterm> minterms,
-                        vector<Token> uniqueVariables) {
+string canonicalSoPToString(vector<Minterm> minterms,
+                            vector<Token> uniqueVariables) {
   string mintermsString = "";
 
   for (int i = 0; i < minterms.size(); i++) {

--- a/src/logic_utils/minterm.h
+++ b/src/logic_utils/minterm.h
@@ -13,6 +13,14 @@ struct Minterm {
   vector<int> binary;
   int num_ones;
   bool is_covered;
+  bool operator==(const Minterm& other) const {
+    if (index != other.index || binary != other.binary ||
+        num_ones != other.num_ones) {
+      return false;
+    }
+
+    return true;
+  }
 };
 
 string mintermToString(Minterm minterm, vector<Token> uniqueVariables);

--- a/src/logic_utils/minterm.h
+++ b/src/logic_utils/minterm.h
@@ -17,7 +17,7 @@ struct Minterm {
 
 string mintermToString(Minterm minterm, vector<Token> uniqueVariables);
 
-string mintermsToString(vector<Minterm> minterms,
-                        vector<Token> uniqueVariables);
+string canonicalSoPToString(vector<Minterm> minterms,
+                            vector<Token> uniqueVariables);
 
 #endif  // MINTERM_H

--- a/src/logic_utils/minterm.h
+++ b/src/logic_utils/minterm.h
@@ -13,7 +13,8 @@ struct Minterm {
   vector<int> binary;
   int num_ones;
   bool is_covered;
-  bool operator==(const Minterm& other) const {
+
+  bool operator==(Minterm& other) {
     if (index != other.index || binary != other.binary ||
         num_ones != other.num_ones) {
       return false;

--- a/src/qm/uncovered_minterms.cpp
+++ b/src/qm/uncovered_minterms.cpp
@@ -1,0 +1,28 @@
+#include <algorithm>
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+#include "implicant.h"
+#include "minterm.h"
+
+vector<Minterm> getUncoveredMinterms(
+    vector<Minterm>& minterms, const vector<Implicant>& essentialImplicants) {
+  vector<Minterm> uncoveredMinterms;
+
+  for (const Implicant& implicant : essentialImplicants) {
+    for (int mintermIndex : implicant.minterms) {
+      Minterm& minterm = minterms[mintermIndex];
+      minterm.is_covered = true;
+    }
+  }
+
+  for (Minterm& minterm : minterms) {
+    if (!minterm.is_covered) {
+      uncoveredMinterms.push_back(minterm);
+    }
+  }
+
+  return uncoveredMinterms;
+}

--- a/src/qm/uncovered_minterms.cpp
+++ b/src/qm/uncovered_minterms.cpp
@@ -4,7 +4,7 @@
 
 using namespace std;
 
-#include "../src/logic_utils/minterm.h"
+#include "../logic_utils/minterm.h"
 #include "implicant.h"
 
 vector<Minterm> getUncoveredMinterms(

--- a/src/qm/uncovered_minterms.cpp
+++ b/src/qm/uncovered_minterms.cpp
@@ -4,8 +4,8 @@
 
 using namespace std;
 
+#include "../src/logic_utils/minterm.h"
 #include "implicant.h"
-#include "minterm.h"
 
 vector<Minterm> getUncoveredMinterms(
     vector<Minterm>& minterms, const vector<Implicant>& essentialImplicants) {

--- a/src/qm/uncovered_minterms.h
+++ b/src/qm/uncovered_minterms.h
@@ -1,6 +1,6 @@
 #ifndef UNCOVERED_MINTERMS_H
 #define UNCOVERED_MINTERMS_H
-#include "../src/logic_utils/minterm.h"
+#include "../logic_utils/minterm.h"
 #include "implicant.h"
 vector<int> getUncoveredMinterms(vector<Minterm>& minterms,
                                  const vector<Implicant>& essentialImplicants);

--- a/src/qm/uncovered_minterms.h
+++ b/src/qm/uncovered_minterms.h
@@ -1,7 +1,7 @@
 #ifndef UNCOVERED_MINTERMS_H
 #define UNCOVERED_MINTERMS_H
+#include "../src/logic_utils/minterm.h"
 #include "implicant.h"
-#include "minterm.h"
 vector<int> getUncoveredMinterms(vector<Minterm>& minterms,
                                  const vector<Implicant>& essentialImplicants);
 

--- a/src/qm/uncovered_minterms.h
+++ b/src/qm/uncovered_minterms.h
@@ -2,7 +2,7 @@
 #define UNCOVERED_MINTERMS_H
 #include "../logic_utils/minterm.h"
 #include "implicant.h"
-vector<int> getUncoveredMinterms(vector<Minterm>& minterms,
-                                 const vector<Implicant>& essentialImplicants);
+vector<Minterm> getUncoveredMinterms(
+    vector<Minterm>& minterms, const vector<Implicant>& essentialImplicants);
 
 #endif

--- a/src/qm/uncovered_minterms.h
+++ b/src/qm/uncovered_minterms.h
@@ -1,0 +1,8 @@
+#ifndef UNCOVERED_MINTERMS_H
+#define UNCOVERED_MINTERMS_H
+#include "implicant.h"
+#include "minterm.h"
+vector<int> getUncoveredMinterms(vector<Minterm>& minterms,
+                                 const vector<Implicant>& essentialImplicants);
+
+#endif

--- a/tests/test_canonical_forms.cpp
+++ b/tests/test_canonical_forms.cpp
@@ -20,8 +20,8 @@ TEST_CASE("Validation of canonical SoP and PoS of  A + B * C' ") {
 
   vector<Maxterm> maxterms = generateMaxTerms(uniqueVariables, truthTable);
 
-  string mintermsString = mintermsToString(minterms, uniqueVariables);
-  string maxtermsString = maxtermsToString(maxterms, uniqueVariables);
+  string mintermsString = canonicalSoPToString(minterms, uniqueVariables);
+  string maxtermsString = canonicalPoSToString(maxterms, uniqueVariables);
 
   REQUIRE(mintermsString == "AB'C'+A'BC'+ABC'+AB'C+ABC");
   REQUIRE(maxtermsString == "(A+B+C)(A+B+C')(A+B'+C')");
@@ -38,8 +38,8 @@ TEST_CASE("Validation of canonical SoP and PoS of  a'bc + ab' + bc' ") {
 
   vector<Maxterm> maxterms = generateMaxTerms(uniqueVariables, truthTable);
 
-  string mintermsString = mintermsToString(minterms, uniqueVariables);
-  string maxtermsString = maxtermsToString(maxterms, uniqueVariables);
+  string mintermsString = canonicalSoPToString(minterms, uniqueVariables);
+  string maxtermsString = canonicalPoSToString(maxterms, uniqueVariables);
 
   REQUIRE(mintermsString == "ab'c'+a'bc'+abc'+ab'c+a'bc");
   REQUIRE(maxtermsString == "(a+b+c)(a+b+c')(a'+b'+c')");
@@ -56,8 +56,8 @@ TEST_CASE("Validation of canonical SoP and PoS of  a+b+c+d ") {
 
   vector<Maxterm> maxterms = generateMaxTerms(uniqueVariables, truthTable);
 
-  string mintermsString = mintermsToString(minterms, uniqueVariables);
-  string maxtermsString = maxtermsToString(maxterms, uniqueVariables);
+  string mintermsString = canonicalSoPToString(minterms, uniqueVariables);
+  string maxtermsString = canonicalPoSToString(maxterms, uniqueVariables);
 
   REQUIRE(mintermsString ==
           "ab'c'd'+a'bc'd'+abc'd'+a'b'cd'+ab'cd'+a'bcd'+abcd'+a'b'c'd+ab'c'd+a'"

--- a/tests/test_uncovered_minterms.cpp
+++ b/tests/test_uncovered_minterms.cpp
@@ -3,6 +3,31 @@
 
 #include "../src/qm/uncovered_minterms.h"
 
+void compareMinterms(const vector<Minterm>& output,
+                     const vector<Minterm>& expected,
+                     vector<Token> variableTokens) {
+  REQUIRE(output.size() == expected.size());
+
+  // find the minterm in output that matches the minterm in expected
+  for (const auto& expected_minterm : expected) {
+    bool found = false;
+    for (const auto& output_minterm : output) {
+      if (expected_minterm.index == output_minterm.index) {
+        found = true;
+        INFO("Expected minterm: " << mintermToString(expected_minterm,
+                                                     variableTokens));
+        INFO("Output minterm: " << mintermToString(output_minterm,
+                                                   variableTokens));
+        REQUIRE(expected_minterm == output_minterm);
+        break;
+      }
+    }
+    INFO("Expected not found minterm: " << mintermToString(expected_minterm,
+                                                           variableTokens));
+    REQUIRE(found);
+  }
+}
+
 TEST_CASE("All minterms covered by essential implicants") {
   vector<Minterm> minterms = {{0, {0, 0}, 0, false},
                               {1, {0, 1}, 1, false},
@@ -11,7 +36,7 @@ TEST_CASE("All minterms covered by essential implicants") {
   vector<Implicant> essentialImplicants = {
       {{1, 0}, {-1, 1}, true, true, false},
       {{3, 2}, {1, -1}, true, true, false}};
-  vector<int> uncoveredMinterms =
+  vector<Minterm> uncoveredMinterms =
       getUncoveredMinterms(minterms, essentialImplicants);
   REQUIRE(uncoveredMinterms.empty());
 }
@@ -23,7 +48,7 @@ TEST_CASE("Some minterms covered by essential implicants") {
                               {3, {1, 1}, 2, false}};
   vector<Implicant> essentialImplicants = {{{1}, {0, 1}, true, true, false},
                                            {{3, 2}, {1, 0}, true, true, false}};
-  vector<int> uncoveredMinterms =
+  vector<Minterm> uncoveredMinterms =
       getUncoveredMinterms(minterms, essentialImplicants);
-  REQUIRE(uncoveredMinterms == vector<int>{0});
+  REQUIRE(uncoveredMinterms == vector<Minterm>{{0, {0, 0}, 0, false}});
 }

--- a/tests/test_uncovered_minterms.cpp
+++ b/tests/test_uncovered_minterms.cpp
@@ -2,16 +2,10 @@
 
 #include <algorithm>
 #include <catch2/catch_test_macros.hpp>
-#include <vector>
 
 #include "../src/qm/uncovered_minterms.h"
 
 void compareMinterms(vector<Minterm>& output, vector<Minterm>& expected) {
-  sort(output.begin(), output.end(),
-       [](Minterm& a, Minterm& b) { return a.index < b.index; });
-  sort(expected.begin(), expected.end(),
-       [](Minterm& a, Minterm& b) { return a.index < b.index; });
-
   REQUIRE(output.size() == expected.size());
 
   for (auto& expected_minterm : expected) {
@@ -52,5 +46,5 @@ TEST_CASE("Some minterms covered by essential implicants") {
                                            {{3, 2}, {1, 0}, true, true, false}};
   vector<Minterm> uncoveredMinterms =
       getUncoveredMinterms(minterms, essentialImplicants);
-  compareMinterms(uncoveredMinterms, vector<Minterm>{{0, {0, 0}, 0, false}});
+  REQUIRE(uncoveredMinterms == vector<Minterm>{{0, {0, 0}, 0, false}});
 }

--- a/tests/test_uncovered_minterms.cpp
+++ b/tests/test_uncovered_minterms.cpp
@@ -1,12 +1,16 @@
 #define CATCH_CONFIG_MAIN
+#include <algorithm>
 #include <catch2/catch_test_macros.hpp>
 
 #include "../src/qm/uncovered_minterms.h"
 
 void compareMinterms(const vector<Minterm>& output,
                      const vector<Minterm>& expected) {
-  sort(output.begin(), output.end());
-  sort(expected.begin(), expected.end());
+  sort(output.begin(), output.end(),
+       [](const Minterm& a, const Minterm& b) { return a.index < b.index; });
+  sort(expected.begin(), expected.end(),
+       [](const Minterm& a, const Minterm& b) { return a.index < b.index; });
+
   REQUIRE(output.size() == expected.size());
 
   for (const auto& expected_minterm : expected) {

--- a/tests/test_uncovered_minterms.cpp
+++ b/tests/test_uncovered_minterms.cpp
@@ -4,18 +4,17 @@
 
 #include "../src/qm/uncovered_minterms.h"
 
-void compareMinterms(const vector<Minterm>& output,
-                     const vector<Minterm>& expected) {
+void compareMinterms(vector<Minterm>& output, vector<Minterm>& expected) {
   sort(output.begin(), output.end(),
-       [](const Minterm& a, const Minterm& b) { return a.index < b.index; });
+       [](Minterm& a, Minterm& b) { return a.index < b.index; });
   sort(expected.begin(), expected.end(),
-       [](const Minterm& a, const Minterm& b) { return a.index < b.index; });
+       [](Minterm& a, Minterm& b) { return a.index < b.index; });
 
   REQUIRE(output.size() == expected.size());
 
-  for (const auto& expected_minterm : expected) {
+  for (auto& expected_minterm : expected) {
     bool found = false;
-    for (const auto& output_minterm : output) {
+    for (auto& output_minterm : output) {
       if (expected_minterm.index == output_minterm.index) {
         found = true;
         INFO("Expected minterm: " << expected_minterm.index);

--- a/tests/test_uncovered_minterms.cpp
+++ b/tests/test_uncovered_minterms.cpp
@@ -1,0 +1,29 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_test_macros.hpp>
+
+#include "../src/qm/uncovered_minterms.h"
+
+TEST_CASE("All minterms covered by essential implicants") {
+  vector<Minterm> minterms = {{0, {0, 0}, 0, false},
+                              {1, {0, 1}, 1, false},
+                              {2, {1, 0}, 1, false},
+                              {3, {1, 1}, 2, false}};
+  vector<Implicant> essentialImplicants = {
+      {{1, 0}, {-1, 1}, true, true, false},
+      {{3, 2}, {1, -1}, true, true, false}};
+  vector<int> uncoveredMinterms =
+      getUncoveredMinterms(minterms, essentialImplicants);
+  REQUIRE(uncoveredMinterms.empty());
+}
+
+TEST_CASE("Some minterms covered by essential implicants") {
+  vector<Minterm> minterms = {{0, {0, 0}, 0, false},
+                              {1, {0, 1}, 1, false},
+                              {2, {1, 0}, 1, false},
+                              {3, {1, 1}, 2, false}};
+  vector<Implicant> essentialImplicants = {{{1}, {0, 1}, true, true, false},
+                                           {{3, 2}, {1, 0}, true, true, false}};
+  vector<int> uncoveredMinterms =
+      getUncoveredMinterms(minterms, essentialImplicants);
+  REQUIRE(uncoveredMinterms == vector<int>{0});
+}

--- a/tests/test_uncovered_minterms.cpp
+++ b/tests/test_uncovered_minterms.cpp
@@ -4,26 +4,23 @@
 #include "../src/qm/uncovered_minterms.h"
 
 void compareMinterms(const vector<Minterm>& output,
-                     const vector<Minterm>& expected,
-                     vector<Token> variableTokens) {
+                     const vector<Minterm>& expected) {
+  sort(output.begin(), output.end());
+  sort(expected.begin(), expected.end());
   REQUIRE(output.size() == expected.size());
 
-  // find the minterm in output that matches the minterm in expected
   for (const auto& expected_minterm : expected) {
     bool found = false;
     for (const auto& output_minterm : output) {
       if (expected_minterm.index == output_minterm.index) {
         found = true;
-        INFO("Expected minterm: " << mintermToString(expected_minterm,
-                                                     variableTokens));
-        INFO("Output minterm: " << mintermToString(output_minterm,
-                                                   variableTokens));
+        INFO("Expected minterm: " << expected_minterm.index);
+        INFO("Output minterm: " << output_minterm.index);
         REQUIRE(expected_minterm == output_minterm);
         break;
       }
     }
-    INFO("Expected not found minterm: " << mintermToString(expected_minterm,
-                                                           variableTokens));
+    INFO("Expected minterm not found: " << expected_minterm.index);
     REQUIRE(found);
   }
 }
@@ -51,4 +48,5 @@ TEST_CASE("Some minterms covered by essential implicants") {
   vector<Minterm> uncoveredMinterms =
       getUncoveredMinterms(minterms, essentialImplicants);
   REQUIRE(uncoveredMinterms == vector<Minterm>{{0, {0, 0}, 0, false}});
+  compareMinterms(uncoveredMinterms, vector<Minterm>{{0, {0, 0}, 0, false}});
 }

--- a/tests/test_uncovered_minterms.cpp
+++ b/tests/test_uncovered_minterms.cpp
@@ -15,7 +15,7 @@ void compareMinterms(vector<Minterm>& output, vector<Minterm>& expected) {
         found = true;
         INFO("Expected minterm: " << expected_minterm.index);
         INFO("Output minterm: " << output_minterm.index);
-        REQUIRE(expected_minterm == output_minterm);
+        REQUIRE(expected_minterm.index == output_minterm.index);
         break;
       }
     }
@@ -24,7 +24,7 @@ void compareMinterms(vector<Minterm>& output, vector<Minterm>& expected) {
   }
 }
 
-TEST_CASE("All minterms covered by essential implicants") {
+TEST_CASE("Test Minterms not covered by essential implicants (1)") {
   vector<Minterm> minterms = {{0, {0, 0}, 0, false},
                               {1, {0, 1}, 1, false},
                               {2, {1, 0}, 1, false},
@@ -37,7 +37,7 @@ TEST_CASE("All minterms covered by essential implicants") {
   REQUIRE(uncoveredMinterms.empty());
 }
 
-TEST_CASE("Some minterms covered by essential implicants") {
+TEST_CASE("Test Minterms not covered by essential implicants (2)") {
   vector<Minterm> minterms = {{0, {0, 0}, 0, false},
                               {1, {0, 1}, 1, false},
                               {2, {1, 0}, 1, false},
@@ -46,5 +46,23 @@ TEST_CASE("Some minterms covered by essential implicants") {
                                            {{3, 2}, {1, 0}, true, true, false}};
   vector<Minterm> uncoveredMinterms =
       getUncoveredMinterms(minterms, essentialImplicants);
-  REQUIRE(uncoveredMinterms == vector<Minterm>{{0, {0, 0}, 0, false}});
+    
+  vector<Minterm> expected = {{0, {0, 0}, 0, false}};
+
+  compareMinterms(uncoveredMinterms, expected);
+}
+
+TEST_CASE("Test Minterms not covered by essential implicants (3)") {
+  vector<Minterm> minterms = {{0, {0, 0}, 0, false},
+                              {1, {0, 1}, 1, false},
+                              {2, {1, 0}, 1, false},
+                              {3, {1, 1}, 2, false}};
+  vector<Implicant> essentialImplicants = {{{1}, {0, 1}, true, true, false},
+                                           {{3, 2}, {1, 0}, true, true, false}};
+  vector<Minterm> uncoveredMinterms =
+      getUncoveredMinterms(minterms, essentialImplicants);
+    
+  vector<Minterm> expected = {{0, {0, 0}, 0, false}};
+
+  compareMinterms(uncoveredMinterms, expected);
 }

--- a/tests/test_uncovered_minterms.cpp
+++ b/tests/test_uncovered_minterms.cpp
@@ -1,6 +1,8 @@
 #define CATCH_CONFIG_MAIN
+
 #include <algorithm>
 #include <catch2/catch_test_macros.hpp>
+#include <vector>
 
 #include "../src/qm/uncovered_minterms.h"
 
@@ -50,6 +52,5 @@ TEST_CASE("Some minterms covered by essential implicants") {
                                            {{3, 2}, {1, 0}, true, true, false}};
   vector<Minterm> uncoveredMinterms =
       getUncoveredMinterms(minterms, essentialImplicants);
-  REQUIRE(uncoveredMinterms == vector<Minterm>{{0, {0, 0}, 0, false}});
   compareMinterms(uncoveredMinterms, vector<Minterm>{{0, {0, 0}, 0, false}});
 }


### PR DESCRIPTION
Added a function to return uncovered minterms from a vector of implicants.