### PR TITLE
Added EPI generator

### DIFF
--- a/src/qm/essential_prime_implicants.cpp
+++ b/src/qm/essential_prime_implicants.cpp
@@ -1,0 +1,51 @@
+#include "essential_prime_implicants.h"
+
+#include <map>
+using namespace std;
+
+bool compareImplicants(const Implicant& a, const Implicant& b) {
+  if (a.minterms.size() != b.minterms.size()) {
+    return a.minterms.size() < b.minterms.size();
+  }
+
+  // Both have the same size
+  for (size_t i = 0; i < a.minterms.size(); ++i) {
+    if (a.minterms[i] != b.minterms[i]) {
+      return a.minterms[i] < b.minterms[i];
+    }
+  }
+
+  // If they're equivalent at this point, return false (since neither is "less"
+  // than the other)
+  return false;
+}
+vector<Implicant> generateEssentialPrimeImplicants(
+    const vector<Implicant>& primeImplicants) {
+  vector<Implicant> essentialImplicants;
+  map<int, vector<const Implicant*>> mintermToImplicantMap;
+
+  // Map minterms to the implicants they belong to
+  for (const auto& implicant : primeImplicants) {
+    for (const int minterm : implicant.minterms) {
+      mintermToImplicantMap[minterm].push_back(&implicant);
+    }
+  }
+
+  for (const auto& pair : mintermToImplicantMap) {
+    // If a minterm is covered by only one prime implicant, that implicant is
+    // essential
+    if (pair.second.size() == 1) {
+      Implicant essentialImplicant = *(pair.second[0]);
+      if (find(essentialImplicants.begin(), essentialImplicants.end(),
+               essentialImplicant) == essentialImplicants.end()) {
+        essentialImplicants.push_back(essentialImplicant);
+      }
+    }
+  }
+
+  // Sort the essentialImplicants vector
+  sort(essentialImplicants.begin(), essentialImplicants.end(),
+       compareImplicants);
+
+  return essentialImplicants;
+}

--- a/src/qm/essential_prime_implicants.h
+++ b/src/qm/essential_prime_implicants.h
@@ -1,0 +1,13 @@
+#ifndef ESSENTIAL_PRIME_IMPLICANTS_H
+#define ESSENTIAL_PRIME_IMPLICANTS_H
+
+#include <vector>
+
+#include "implicant.h"
+
+using namespace std;
+
+vector<Implicant> generateEssentialPrimeImplicants(
+    const std::vector<Implicant>& primeImplicants);
+
+#endif  // ESSENTIAL_IMPLICANTS_H

--- a/src/qm/implicant.cpp
+++ b/src/qm/implicant.cpp
@@ -7,7 +7,7 @@
 
 using namespace std;
 
-string implicantToString(const Implicant &implicant,
+string implicantToString(const Implicant& implicant,
                          vector<Token> variableTokens) {
   string result;
 
@@ -22,4 +22,19 @@ string implicantToString(const Implicant &implicant,
   }
 
   return result;
+}
+
+ostream& operator<<(ostream& os, const Implicant& imp) {
+  os << "{ Minterms: [";
+  for (const auto& m : imp.minterms) {
+    os << m << ",";
+  }
+  os << "], Binary: [";
+  for (const auto& b : imp.binary) {
+    os << b << ",";
+  }
+  os << "], is_prime: " << imp.is_prime;
+  os << ", is_essential: " << imp.is_essential;
+  os << ", is_checked: " << imp.is_checked << " }";
+  return os;
 }

--- a/src/qm/implicant.h
+++ b/src/qm/implicant.h
@@ -2,6 +2,7 @@
 #define IMPLICANT_H
 
 #include <algorithm>
+#include <iostream>
 #include <vector>
 
 #include "../logic_utils/token.h"
@@ -15,7 +16,7 @@ struct Implicant {
   bool is_essential;
   bool is_checked;
 
-  bool operator==(const Implicant &other) const {
+  bool operator==(const Implicant& other) const {
     if (minterms.size() != other.minterms.size()) {
       return false;
     }
@@ -34,9 +35,11 @@ struct Implicant {
 
     return true;
   }
+
+  friend ostream& operator<<(ostream& os, const Implicant& imp);
 };
 
-string implicantToString(const Implicant &implicant,
+string implicantToString(const Implicant& implicant,
                          vector<Token> variableTokens);
 
 #endif  // IMPLICANT_H

--- a/tests/test_essential_prime_implicants.cpp
+++ b/tests/test_essential_prime_implicants.cpp
@@ -1,0 +1,41 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_test_macros.hpp>
+
+#include "../src/qm/essential_prime_implicants.h"
+
+TEST_CASE("Essential Prime Implicants when all PIs are essential") {
+  vector<Implicant> primeImplicants = {{{0, 1}, {0, -1}, false, false, false},
+                                       {{2, 3}, {1, -1}, false, false, false}};
+
+  vector<Implicant> expectedEssentialImplicants = primeImplicants;
+
+  REQUIRE(generateEssentialPrimeImplicants(primeImplicants) ==
+          expectedEssentialImplicants);
+}
+
+TEST_CASE("Essential Prime Implicants when no PIs are essential") {
+  vector<Implicant> primeImplicants = {
+      {{0, 1, 2, 3}, {-1, -1}, false, false, false},
+      {{0, 1}, {0, -1}, false, false, false},
+      {{2, 3}, {1, -1}, false, false, false}};
+
+  vector<Implicant> expectedEssentialImplicants = {};
+
+  REQUIRE(generateEssentialPrimeImplicants(primeImplicants) ==
+          expectedEssentialImplicants);
+}
+
+TEST_CASE("Essential Prime Implicants for mixed scenario") {
+  vector<Implicant> primeImplicants = {
+      {{0, 1, 4, 5}, {-1, 0, -1}, false, false, false},
+      {{0, 1}, {0, 0, -1}, false, false, false},
+      {{2, 3, 6, 7}, {1, -1, -1}, false, false, false},
+      {{6, 7}, {1, 1, -1}, false, false, false}};
+
+  vector<Implicant> expectedEssentialImplicants = {
+      {{0, 1, 4, 5}, {-1, 0, -1}, false, false, false},
+      {{2, 3, 6, 7}, {1, -1, -1}, false, false, false}};
+
+  REQUIRE(generateEssentialPrimeImplicants(primeImplicants) ==
+          expectedEssentialImplicants);
+}

--- a/tests/test_essential_prime_implicants.cpp
+++ b/tests/test_essential_prime_implicants.cpp
@@ -3,15 +3,21 @@
 
 #include "../src/qm/essential_prime_implicants.h"
 
-TEST_CASE("Essential Prime Implicants when all PIs are essential") {
-  vector<Implicant> primeImplicants = {{{0, 1}, {0, -1}, false, false, false},
-                                       {{2, 3}, {1, -1}, false, false, false}};
+TEST_CASE("Essential Prime Implicants") {
+  vector<Implicant> primeImplicants = 
+    {{{0, 2, 4, 6}, {0, -1, -1, 0}, false, false, false},
+    {{0, 1, 8, 9}, {-1, 0, 0, -1}, false, false, false},
+    {{9, 11, 13, 15}, {1, -1, -1, 1}, false, false, false}};
 
-  vector<Implicant> expectedEssentialImplicants = primeImplicants;
+  vector<Implicant> expectedEssentialImplicants = 
+    {{{0, 1, 8, 9}, {-1, 0, 0, -1}, false, false, false},
+    {{0, 2, 4, 6}, {0, -1, -1, 0}, false, false, false},
+    {{9, 11, 13, 15}, {1, -1, -1, 1}, false, false, false}};
 
   REQUIRE(generateEssentialPrimeImplicants(primeImplicants) ==
           expectedEssentialImplicants);
 }
+
 
 TEST_CASE("Essential Prime Implicants when no PIs are essential") {
   vector<Implicant> primeImplicants = {
@@ -35,6 +41,26 @@ TEST_CASE("Essential Prime Implicants for mixed scenario") {
   vector<Implicant> expectedEssentialImplicants = {
       {{0, 1, 4, 5}, {-1, 0, -1}, false, false, false},
       {{2, 3, 6, 7}, {1, -1, -1}, false, false, false}};
+
+  REQUIRE(generateEssentialPrimeImplicants(primeImplicants) ==
+          expectedEssentialImplicants);
+}
+
+TEST_CASE("Essential Prime Implicants ") {
+  vector<Implicant> primeImplicants =
+    {{{10, 26}, {0, -1, 1, 0, 1, 0}, false, false, false},
+    {{10, 42}, {-1, 0, 1, 0, 1, 0}, false, false, false},
+    {{18, 26}, {0, 1, -1, 0, 1, 0}, false, false, false},
+    {{18, 50}, {-1, 1, 0, 0, 1, 0}, false, false, false},
+    {{40, 42}, {1, 0, 1, 0, -1, 0}, false, false, false},
+    {{48, 50}, {1, 1, 0, 0, -1, 0}, false, false, false},
+    {{40, 41, 56, 57}, {1, -1, 1, 0, 0, -1}, false, false, false},
+    {{48, 49, 52, 53, 56, 57, 60, 61}, {1, 1, -1, -1, 0, -1}, false, false, false}};
+
+  vector<Implicant> expectedEssentialImplicants = 
+    {
+    {{40, 41, 56, 57}, {1, -1, 1, 0, 0, -1}, false, false, false},
+    {{48, 49, 52, 53, 56, 57, 60, 61}, {1, 1, -1, -1, 0, -1}, false, false, false}};
 
   REQUIRE(generateEssentialPrimeImplicants(primeImplicants) ==
           expectedEssentialImplicants);


### PR DESCRIPTION
We're optimizing the generation of essential prime implicants to ensure the code's clarity, efficiency, and maintainability.
Introduced the `generateEssentialPrimeImplicants` function which maps minterms to the implicants they belong to and subsequently determines essential prime implicants.
Leveraged the standard library's `map` for an intuitive and effective grouping of minterms and implicants.
Implemented a concise check to determine if a minterm is covered by only one prime implicant, designating it as essential.
Lastly, implemented a sorting function to sort the `vector` of essential prime implicants according to the sorting algorithm in `Implicant.cpp` file.

This PR resolves #32 